### PR TITLE
Multiply rank on 10^15 to resemble rank results in node

### DIFF
--- a/cyber-rank/cyber~Rank.ipynb
+++ b/cyber-rank/cyber~Rank.ipynb
@@ -168,6 +168,7 @@
     "        change = abs(max(rank) - max(prevrank))\n",
     "        prevrank = rank\n",
     "        steps += 1\n",
+    "    rank = [round(element * 1_000_000_000_000_000) for element in rank]\n",
     "    res = list(zip(objects, rank))\n",
     "    res.sort(reverse=True, key=lambda x: x[1])\n",
     "    return res"


### PR DESCRIPTION
@litvintech said in the [swagger](https://lcd.bostrom.cybernode.ai/cyber/rank/v1beta1/rank/search/QmWbTb3NFfBXMrJ5GbUQSxdoYL8CMAtQ1oV4LsPXNhTfMF) results are shown as they are in the cybernode. And to normalize them, we need to multiply rank according to the formula on 10^15. I'm not sure if there should be used ROUND() of INT(); please check. 