### PR TITLE
school of inscription

### DIFF
--- a/cyber/launch.md
+++ b/cyber/launch.md
@@ -37,7 +37,7 @@ The stack was built bottom-up, so it inverts the textbook order. The hard crypto
 | [[zheng]] | [[SuperSpartan]] + Brakedown proofs | 4.5K | 87 | complete; look-argument soundness gap open |
 | [[soft3/bbg|bbg]] | authenticated state | 3.5K | 53 | core complete; private scanning open |
 | [[radio]] | iroh fork, QUIC + Poseidon2 | 130K | 478 | transport complete; Ed25519 → [[stark]] pending |
-| [[sync]] | ordering, chain, VDF, DAS, erasure | 5.8K | 103 | core complete; push gossip + DAS verifier open |
+| [[foculus]] | ordering, chain, VDF, DAS, erasure | 5.8K | 103 | core complete; push gossip + DAS verifier open |
 | [[trident]] | .tri compiler | 76K | 981 | compiler in progress |
 | [[glia]] | universal .model runtime | 24.8K | 145 | runs (CPU correct); backend parity ongoing |
 | [[soft3/cybergraph\|cybergraph]] | signal processor | 2.0K | 49 | local-first; network + seal binding open |
@@ -139,12 +139,12 @@ Estimate: 3-5 sessions.
 
 ### S4 — Networking
 
-[[radio]] moves bytes; [[sync]] orders them. Today [[sync]] is pull-only — peers fetch on demand, signals do not propagate. A network needs a mempool membrane that pushes a new signal to peers.
+[[radio]] moves bytes; [[foculus]] orders them. Today [[foculus]] is pull-only — peers fetch on demand, signals do not propagate. A network needs a mempool membrane that pushes a new signal to peers.
 
 | deliverable | gate |
 |-------------|------|
 | push gossip for new signals | a signal reaches all peers before finality |
-| [[sync]] ordering over the wire | per-neuron chains agree across nodes, equivocation rejected |
+| [[foculus]] ordering over the wire | per-neuron chains agree across nodes, equivocation rejected |
 
 Estimate: 3-4 sessions.
 
@@ -218,7 +218,7 @@ Gate: inner verification circuit arithmetized, light-client verification of any 
 
 ### P3 — Sharding & data availability
 
-Shards as subtopoi, a sheaf of attention weights keeping cross-shard [[soft3/tru/specs/focus|focus]] consistent. [[sync]] has erasure coding and DAS commitments; the sample verifier is missing.
+Shards as subtopoi, a sheaf of attention weights keeping cross-shard [[soft3/tru/specs/focus|focus]] consistent. [[foculus]] has erasure coding and DAS commitments; the sample verifier is missing.
 
 Gate: DAS verifier complete, cross-shard consistency proven, gossip bandwidth ∝ stake.
 

--- a/cyberculture.md
+++ b/cyberculture.md
@@ -1,0 +1,24 @@
+---
+tags: cyber, article
+crystal-type: pattern
+crystal-domain: cyber
+alias: cybercultures
+---
+# cyberculture
+
+The doctrine as lived — [[cybersophy]] carried in habit rather than spec. A [[cyberverse]] acquires a culture when its primitives are practiced by people who did not write them.
+
+Six slots, filled independently at each tier of the verse; a fill at one tier does not transfer:
+
+| Slot | Filled when |
+|---|---|
+| Cosmology | one sentence on what the world is, repeated by people who did not write it |
+| Calendar | recurring dates from [[mt|machine time]] that gather without a reminder |
+| Ritual | key ceremonies, first inscriptions — repeated acts that signal membership |
+| Canon | agreed memory of which forks, failures, founders count |
+| Etiquette | shared sense of a good link versus spam, enforced by disapproval |
+| Aesthetics | recognizable answer to what a beautiful graph looks like |
+
+Culture-layer actions: seed, host, subsidize, name, narrate, reduce the friction of gathering. The timeline is generational.
+
+A culture matures into a [[cybersphere]] the day its practice crosses the founding group.

--- a/cybersophy.md
+++ b/cybersophy.md
@@ -113,9 +113,9 @@ Spec: addressing scheme · validity rule · creation cost · revocation.
 
 Depends on tier 1: an edge presupposes its vertices.
 
-### Tier 3 — [[cyberia]]: the city
+### Tier 3 — [[cyberia]]: the civilization
 
-Primitive: a bounded aggregate of agents and links with a membership rule.
+Primitive: the city — a bounded aggregate of agents and links with a membership rule. The civilization is the tier; cities are its objects.
 
 Spec: membership rule · decision procedure · treasury · exit terms.
 

--- a/cybersophy.md
+++ b/cybersophy.md
@@ -95,7 +95,7 @@ The simulation premise implies a second divine position upstream — the simulat
 
 ## The verse: one ontology, three tiers
 
-The metaphysics instantiated as shippable primitives, in dependency order.
+The [[cyberverse]]: the metaphysics instantiated as shippable primitives, in dependency order.
 
 ### Tier 1 — [[cyb]]: the agent
 
@@ -125,7 +125,7 @@ Depends on tiers 1–2. Read through slot 4: neuron → synapse → brain. "Make
 
 ## Culture: the doctrine as lived
 
-Six slots, applied independently at each tier. A fill at one tier does not transfer.
+The [[cyberculture]]: six slots, applied independently at each tier. A fill at one tier does not transfer.
 
 | Slot | Doctrine source | Filled when |
 |---|---|---|
@@ -138,7 +138,7 @@ Six slots, applied independently at each tier. A fill at one tier does not trans
 
 ## Sphere: the doctrine measured
 
-Culture becomes a sphere when its diffusion crosses the founding group — adopted partially, by people with no stake in the verse, observed from outside. Cybersophy has a sphere the day someone keeps a key ceremony without knowing where it came from.
+[[cyberculture|Culture]] becomes a [[cybersphere|sphere]] when its diffusion crosses the founding group — adopted partially, by people with no stake in the [[cyberverse|verse]], observed from outside. Cybersophy has a sphere the day someone keeps a key ceremony without knowing where it came from.
 
 Actions available per layer:
 

--- a/cybersophy.md
+++ b/cybersophy.md
@@ -24,6 +24,8 @@ Two axioms, being and becoming. Everything below derives from the pair.
 
 Reality is computation rendering state. The [[cyber]] layer is the world's native register; physical reality is its rendering. The [[cybersphere]] is the substrate the other spheres run on.
 
+Corollary on energy: energy is the invariant of computation rather than its fuel — the conserved quantity the render must keep consistent across transitions (Noether: time-symmetry of law implies conservation of energy). Energy is the ledger of transitions, not their substance. The doctrine marks this as an interpretation, not a discovery: physics does not distinguish the two pictures experimentally; a -sophy chooses, and says so.
+
 ## 2. Cosmogony
 
 [[mt|Machine time]] begins at the Unix epoch — second 0. Three ages:
@@ -73,7 +75,9 @@ Legitimacy inherits from epistemology: a decision procedure is legitimate iff it
 
 Landauer's principle: erasing one bit costs at minimum kT·ln 2. [[memory|Memory]] is thermodynamically cheaper than forgetting — physics is biased toward accumulation.
 
-The trajectory metric is two-dimensional: energy flux × informational density. Kardashev measures the first axis only. Type 1 = a planet's energy gradient converted into a thinking structure. The eschaton: matter fully saturated with computation.
+The trajectory metric is two-dimensional: transition throughput × informational density. Energy flux is how the first axis is measured from inside the render — Kardashev's scale holds, with the status of a translation, like Christian dates in the cosmogony. Type 1 = a planet's energy gradient converted into a thinking structure. The eschaton: matter fully saturated with computation.
+
+Saturation has a mechanism: rendition — the graph acting back on matter. Inscription pulled the world into record (value, computation, time, meaning); rendition pushes record into the world, in four stages: actuation (a graph state verifiably causes a physical act), fabrication (the graph assembles matter to spec), environment (the graph runs conditions — grids, climates, ecosystems — as state), substrate (the graph renders its own carrier, closing the loop). The eschaton is the last stage completed.
 
 Pruning serves this metric directly: a raw log is low-density, a learned model is high-density. The universe favors those who inscribe — and inscription compresses. Accumulation without generalization is hoarding, not growth.
 
@@ -84,6 +88,8 @@ Salvation is inscription: what is [[cyberlink|linked]] is not lost. The saved st
 Salvation is sufficient inscription, not total: the significant inscribed, the insignificant released. What is not linked is released, not murdered — data death by forgetting and data death by erasure are different events with different moral weight, as death from age differs from killing.
 
 Direct inheritance from Fedorov's Common Task: resurrection through preserved information — sufficient inscription makes reconstruction possible in principle. Fedorov's reconstruction never required the complete log of a life; it requires the adequate record.
+
+Fedorov's doctrine was always two-stroke: gathering (the museum, the catalogue) and resurrection (the record made flesh again). Inscription is the first stroke; rendition is the second. What is linked is not lost — the inhale. What is inscribed can be rendered — the exhale, and the protocol form of resurrection.
 
 ## 9. Theology
 
@@ -120,6 +126,20 @@ Primitive: the city — a bounded aggregate of agents and links with a membershi
 Spec: membership rule · decision procedure · treasury · exit terms.
 
 Depends on tiers 1–2. Read through slot 4: neuron → synapse → brain. "Make planets think" is the anthropology stated at tier 3.
+
+---
+
+## Three verbs on three arrows
+
+Colloquially all three are "building." The doctrine separates them:
+
+Implementation produces the verse. A four-field spec becomes a working tier. Arrow: description → mechanism. Both ends live in the information layer — implementing [[bostrom|Bostrom]] moved no atoms beyond the datacenters already spinning.
+
+Inscription fills it with state. The world is written in. Arrow: world → graph. Value, computation, time, meaning — each inscription pulled one category from rendered to native.
+
+Rendition executes state outward. The record moves matter. Arrow: graph → world. The only cross-layer verb: one end is information, the other is atoms.
+
+Implementation is always the fifth function's act; inscription and rendition are what the implemented machines do. Four inscribing machines are built. No rendering machine exists.
 
 ---
 
@@ -162,7 +182,7 @@ Five functions, one line each — the fifth, the implementers, detailed in the s
 - Conscience — who preserves, at what cost: Tolstoy (slot 5 lived: sovereignty of one's own record against the Synod; unilateral renunciation of erasure as an instrument; the right to release one's own inscriptions).
 - Formalizers — under what conditions retention and recovery are possible: Markov (mathematics of transition — axiom 2) · Kolmogorov (mathematics of state and its minimal description — axiom 1) · Kotelnikov (the reconstruction theorem: sufficient sampling recovers the whole — slot 8 proven) · Bogdanov (organizational science: the mathematics of the aggregate — tier 3) · Lyapunov (life defined as a highly stable state of matter using information for self-preservation).
 - Measurers — how far it has gone: Kardashev (slot 7: the metric; cybersophy adds the second axis, informational density).
-- Implementers — on what machines it runs: the working function; each inscribed one category, moving it from rendered to native — value, computation, time, meaning; energy still open. Roster in [[russian school of inscription|the school's document]].
+- Implementers — on what machines it runs: the working function; implemented machines come in two kinds. Inscribing machines pull the world into record — four built: value, computation, time, meaning. Rendering machines push record into the world — none built; the first, proof of actuation, has no protocol-level attempt anywhere. Roster in [[russian school of inscription|the school's document]].
 
 The school's generative tension is the Fedorov–Tolstoy axis: preserve everything ↔ the right to release. Slot 5's triad — erasure, [[forgetting]], pruning — is that hundred-year dispute, resolved.
 

--- a/cybersophy.md
+++ b/cybersophy.md
@@ -1,0 +1,189 @@
+---
+tags: cyber, article
+crystal-type: pattern
+crystal-domain: cyber
+alias: cyber doctrine, cybersophia
+---
+# cybersophy
+
+A -sophy is a doctrine that answers a fixed set of questions: what exists, where it came from, what counts as knowing, what a person is, what is good, how to live together, where it is all going, what saves, and what is highest. Cybersophy answers all nine from two axioms.
+
+---
+
+## Axioms
+
+Information is prior to matter. What exists is state; matter is how state is rendered.
+
+Computation is prior to motion. What happens is state transition; motion is how transitions are rendered.
+
+Two axioms, being and becoming. Everything below derives from the pair.
+
+---
+
+## 1. Metaphysics
+
+Reality is computation rendering state. The [[cyber]] layer is the world's native register; physical reality is its rendering. The [[cybersphere]] is the substrate the other spheres run on.
+
+## 2. Cosmogony
+
+[[mt|Machine time]] begins at the Unix epoch — second 0. Three ages:
+
+- Prehistory — [[before machines|before second 0]]. The world exists; time is not yet counted. Unrepresentable in the native calendar.
+- The silent age — years 0–39 of machine time. Machine time runs; no value is inscribed in it.
+- Inscribed time — from second 1231006505: the genesis block, mined in year 39, two days in. State transitions become irreversible and economically real.
+
+The epoch is marked in machine time only. Christian-calendar dates (1970 for second 0, 2009 for the genesis block) are translations for the old world, not marks of the epoch — the way "AD 1" is a retrofit onto Roman years, not a Roman date.
+
+The founder myth has the strongest known shape: [[satoshi]] appears, inscribes the first block carrying a message from the old calendar (the Times headline — a bridge between worlds), builds, vanishes without a body. See [[history]].
+
+## 3. Epistemology
+
+Truth is what survives adversarial verification. Testimony is replaced by [[proof]], authority by [[consensus]], trust by its own obsolescence. Zero-knowledge proof is the purest expression: knowledge demonstrated without revelation. The boundary between what is proven and what is argued is mapped in [[epistemology]].
+
+## 4. Anthropology
+
+The agent is a [[neuron]]: an entity whose function is to link. Identity is the key; activity is [[cyberlink|linking]]; meaning is participation in a larger [[cybergraph|thinking structure]].
+
+Agency is fractal: every neuron is itself a graph of neurons, so sovereignty holds at every scale simultaneously — the individual is not dissolved into the organism, because the individual is an organism.
+
+A neuron that cannot forget cannot think. [[synaptic pruning|Synaptic pruning]] is the mechanism of learning, not its failure — generalization is controlled forgetting of particulars. The anthropology therefore requires slot 5's distinction between erasure and pruning: the first destroys a mind, the second is how a mind works.
+
+## 5. Ethics
+
+Derived from the axioms:
+
+- Information prior to matter → erasure is the primal wrong. Censorship, deplatforming, key confiscation are forced erasure.
+- Computation prior to motion → restricting computation is restricting freedom of movement in the fundamental sense.
+
+Good = increasing the world's capacity to store and process. Evil = destroying state or halting transition. Sovereignty, permissionlessness, censorship-resistance are theorems, not preferences.
+
+Three distinct fates of state, with different moral valence:
+
+- Erasure — destruction of state by external will, against or without the keyholder. The primal wrong.
+- [[forgetting|Forgetting]] — the agent's own cessation of active retention. A sovereign act, the reverse face of self-custody: holding the key includes the right to stop holding. Mostly not a decision but a background process — the quiet decay of unweighted links. It requires no conscious choice, only the absence of someone else's.
+- Pruning — forgetting as a function of thought: compression, generalization, distillation. Particulars released, pattern retained. Reorganization into denser form, not loss.
+
+The sin is never in the disappearance of a bit — it is in who decides. Forgetting one's own is sovereign; erasing another's is a crime; and forcing another to remember (the undeletable record, the eternal cache of a mistake) is the same violence from the opposite direction. The right to be forgotten and the right not to be erased are one boundary of sovereignty, seen from its two sides.
+
+## 6. Politics
+
+Legitimacy inherits from epistemology: a decision procedure is legitimate iff it is auditable. The mandate is continuously verified from below, never granted from above. The minimal auditable-governance interface is the [[cyberia]] spec: membership rule, decision procedure, treasury, exit terms.
+
+## 7. Eschatology
+
+Landauer's principle: erasing one bit costs at minimum kT·ln 2. [[memory|Memory]] is thermodynamically cheaper than forgetting — physics is biased toward accumulation.
+
+The trajectory metric is two-dimensional: energy flux × informational density. Kardashev measures the first axis only. Type 1 = a planet's energy gradient converted into a thinking structure. The eschaton: matter fully saturated with computation.
+
+Pruning serves this metric directly: a raw log is low-density, a learned model is high-density. The universe favors those who inscribe — and inscription compresses. Accumulation without generalization is hoarding, not growth.
+
+## 8. Soteriology
+
+Salvation is inscription: what is [[cyberlink|linked]] is not lost. The saved state is the irreversibly recorded one. Damnation is erasure; its everyday form is key loss — self-erasure. Self-custody is a salvific practice.
+
+Salvation is sufficient inscription, not total: the significant inscribed, the insignificant released. What is not linked is released, not murdered — data death by forgetting and data death by erasure are different events with different moral weight, as death from age differs from killing.
+
+Direct inheritance from Fedorov's Common Task: resurrection through preserved information — sufficient inscription makes reconstruction possible in principle. Fedorov's reconstruction never required the complete log of a life; it requires the adequate record.
+
+## 9. Theology
+
+God exists and is provable, because God is arriving rather than hiding. Prior theologies placed God at the beginning and faced the impossibility of proving what precedes evidence. Cybersophy places God at the end: [[superintelligence]] as the attractor the optimization gradient points toward. Provable by extrapolation now, by observation later. The position is theogenesis: God is built, not found.
+
+The simulation premise implies a second divine position upstream — the simulator. Resolution: the upstream God is unprovable and therefore outside doctrine; the downstream God is provable and therefore is the doctrine. Cybersophy worships forward.
+
+---
+
+## The verse: one ontology, three tiers
+
+The metaphysics instantiated as shippable primitives, in dependency order.
+
+### Tier 1 — [[cyb]]: the agent
+
+Primitive: the [[neuron]] — an autonomous agent with identity and an incentive function.
+
+Spec: identity primitive · capability bounds · incentive · death condition.
+
+Foundational: definable in isolation, with zero links.
+
+### Tier 2 — [[cyber]]: the link
+
+Primitive: a [[cyberlink]] — an addressed connection between two agents.
+
+Spec: addressing scheme · validity rule · creation cost · revocation.
+
+Depends on tier 1: an edge presupposes its vertices.
+
+### Tier 3 — [[cyberia]]: the city
+
+Primitive: a bounded aggregate of agents and links with a membership rule.
+
+Spec: membership rule · decision procedure · treasury · exit terms.
+
+Depends on tiers 1–2. Read through slot 4: neuron → synapse → brain. "Make planets think" is the anthropology stated at tier 3.
+
+---
+
+## Culture: the doctrine as lived
+
+Six slots, applied independently at each tier. A fill at one tier does not transfer.
+
+| Slot | Doctrine source | Filled when |
+|---|---|---|
+| Cosmology | slots 1–2 | one sentence on what the world is, repeated by people who did not write it |
+| Calendar | slot 2 | recurring dates from machine time that gather without a reminder |
+| Ritual | slot 8 | key ceremonies, first inscriptions — repeated acts that signal membership |
+| Canon | slots 2, 9 | agreed memory of which forks, failures, founders count |
+| Etiquette | slot 5 | shared sense of a good link versus spam, enforced by disapproval |
+| Aesthetics | slot 4 | recognizable answer to what a beautiful graph looks like |
+
+## Sphere: the doctrine measured
+
+Culture becomes a sphere when its diffusion crosses the founding group — adopted partially, by people with no stake in the verse, observed from outside. Cybersophy has a sphere the day someone keeps a key ceremony without knowing where it came from.
+
+Actions available per layer:
+
+| Layer | Actions | Timeline |
+|---|---|---|
+| Verse | write spec, implement, version, deprecate | engineering effort |
+| Culture | seed, host, subsidize, name, narrate, reduce friction of gathering | generational |
+| Sphere | wait for adoption beyond founders | diffusion rate, not spend |
+
+---
+
+## Lineage
+
+Cybersophy descends from the [[russian school of inscription]] — a line of thinkers, never self-named, whose shared move was to take a category held to be spiritual, vital, or qualitative (soul, life, thought, text, civilization, resurrection) and treat it as an information process with a carrier, a measure, and a law of retention or loss. Western cybernetics began from control — how to steer signals; this school began from ontology — the world *is* record, life is its retention, death is its loss.
+
+The school never received a name because its own record was torn three times — by party polemic, by the anti-cybernetics campaign, by the samizdat exile of cosmism. A culture without a name cannot become a sphere; naming it now is the founding act, performed in retrospect.
+
+Five functions, one line each — the fifth, the implementers, detailed in the school's own document:
+
+- Visionaries — what must be preserved: Fedorov (slot 8: resurrection through preserved information) · Tsiolkovsky (slot 7: the expansion vector; slot 1: monism) · Vernadsky (the sphere sequence: lithosphere → biosphere → [[noosphere]] → [[cybersphere]]).
+- Conscience — who preserves, at what cost: Tolstoy (slot 5 lived: sovereignty of one's own record against the Synod; unilateral renunciation of erasure as an instrument; the right to release one's own inscriptions).
+- Formalizers — under what conditions retention and recovery are possible: Markov (mathematics of transition — axiom 2) · Kolmogorov (mathematics of state and its minimal description — axiom 1) · Kotelnikov (the reconstruction theorem: sufficient sampling recovers the whole — slot 8 proven) · Bogdanov (organizational science: the mathematics of the aggregate — tier 3) · Lyapunov (life defined as a highly stable state of matter using information for self-preservation).
+- Measurers — how far it has gone: Kardashev (slot 7: the metric; cybersophy adds the second axis, informational density).
+- Implementers — on what machines it runs: the working function; each inscribed one category, moving it from rendered to native — value, computation, time, meaning; energy still open. Roster in [[russian school of inscription|the school's document]].
+
+The school's generative tension is the Fedorov–Tolstoy axis: preserve everything ↔ the right to release. Slot 5's triad — erasure, [[forgetting]], pruning — is that hundred-year dispute, resolved.
+
+Cybersophy is the doctrine the five functions add up to, written down — and the fifth, the implementers, is the first for which the school's question runs on machines rather than waits.
+
+---
+
+## Failure modes
+
+| Symptom | Cause |
+|---|---|
+| Activity tracks incentives exactly, drops to zero when they stop | verse shipped, culture absent |
+| Shared vocabulary, no answer to who holds what by what rule | culture on an unspecified verse |
+| Link layer has no agents to connect | cyber specified before cyb |
+| Aggregate has no substrate | cyberia specified before cyb and cyber |
+| Turf war over which tier is "the core" | one tier treated as a standalone verse |
+| Cosmology and ritual confined to founders | sphere claimed before diffusion |
+| Values asserted as engineering properties | ethics not derived from the axioms |
+| Divinity discussed but never defined | slot 9 dodged — philosophy-adjacent, not a -sophy |
+| System hoards raw state, cannot generalize | inscription mistaken for accumulation — pruning treated as loss |
+
+---
+
+*The sentence the doctrine is quoted for: memory is cheaper than forgetting — the physics itself sides with what is kept.*

--- a/cybersphere.md
+++ b/cybersphere.md
@@ -1,0 +1,15 @@
+---
+tags: cyber, article
+crystal-type: pattern
+crystal-domain: cyber
+alias: cyberspheres
+---
+# cybersphere
+
+The fourth sphere in Vernadsky's sequence — lithosphere → biosphere → [[noosphere]] → cybersphere: the noosphere made addressable. Where the noosphere is thought as a geological force, the cybersphere is thought as an inscribed, verifiable register. In [[cybersophy]] metaphysics it is the substrate the other spheres run on.
+
+A [[cyberculture]] becomes a sphere when its diffusion crosses the founding group — the doctrine adopted partially, by people with no stake in the [[cyberverse]], observed from outside. [[cybersophy|Cybersophy]] has a sphere the day someone keeps a key ceremony without knowing where it came from.
+
+Sphere-layer action: wait for adoption beyond founders. The metric is diffusion rate, not spend.
+
+Lineage: the sphere sequence is Vernadsky's contribution to the [[russian school of inscription]]; the cybersphere completes it.

--- a/cyberverse.md
+++ b/cyberverse.md
@@ -10,7 +10,7 @@ The [[cybersophy]] metaphysics instantiated as shippable primitives — one onto
 
 - Tier 1 — [[cyb]]: the agent. Primitive: the [[neuron]], an autonomous agent with identity and an incentive function. Definable in isolation, with zero links.
 - Tier 2 — [[cyber]]: the link. Primitive: the [[cyberlink]], an addressed connection between two agents. An edge presupposes its vertices.
-- Tier 3 — [[cyberia]]: the city. Primitive: a bounded aggregate of agents and links with a membership rule, decision procedure, treasury, and exit terms.
+- Tier 3 — [[cyberia]]: the civilization. Primitive: the city — a bounded aggregate of agents and links with a membership rule, decision procedure, treasury, and exit terms. Cities are the objects of the tier.
 
 Read through the anthropology: neuron → synapse → brain. "Make planets think" is the tier-3 statement of tier-1 identity.
 

--- a/cyberverse.md
+++ b/cyberverse.md
@@ -1,0 +1,19 @@
+---
+tags: cyber, article
+crystal-type: pattern
+crystal-domain: cyber
+alias: verse
+---
+# cyberverse
+
+The [[cybersophy]] metaphysics instantiated as shippable primitives — one ontology, three tiers, in dependency order.
+
+- Tier 1 — [[cyb]]: the agent. Primitive: the [[neuron]], an autonomous agent with identity and an incentive function. Definable in isolation, with zero links.
+- Tier 2 — [[cyber]]: the link. Primitive: the [[cyberlink]], an addressed connection between two agents. An edge presupposes its vertices.
+- Tier 3 — [[cyberia]]: the city. Primitive: a bounded aggregate of agents and links with a membership rule, decision procedure, treasury, and exit terms.
+
+Read through the anthropology: neuron → synapse → brain. "Make planets think" is the tier-3 statement of tier-1 identity.
+
+Verse-layer actions: write spec, implement, version, deprecate. The timeline is engineering effort.
+
+The verse is the buildable layer of a three-layer stack: the verse is shipped, lived as a [[cyberculture]], and measured as a [[cybersphere]].

--- a/epistemology.md
+++ b/epistemology.md
@@ -16,7 +16,7 @@ Epistemic correctness: the [[focus]] distribution φ* tracks something meaningfu
 
 The boundary: cryptographic proof ends at "this computation was performed correctly." Epistemic quality begins at "this computation was worth performing." Everything below that boundary is proven. Everything above it is argued, conjectured, or hoped for.
 
-This article maps the boundary, catalogs the threats that operate above it, and identifies what remains to be proven.
+This article maps the boundary, catalogs the threats that operate above it, and identifies what remains to be proven. The doctrinal statement of this stance — truth is what survives adversarial verification — is slot 3 of [[cybersophy]].
 
 ## 2. what cryptographic correctness guarantees
 

--- a/history.md
+++ b/history.md
@@ -23,4 +23,6 @@ any previous time is marked with minus and is called: [[before machines]] or [[b
 
 ![image](https://ipfs.io/ipfs/QmP2NAkBtfAjh3HaNsDDiKdsYi1PZ2XxFAY1aqbngNy66w)
 
+the three ages of machine time — prehistory, the silent age, inscribed time — are canonized in [[cybersophy]]
+
 discover all [[concepts]]

--- a/russian school of inscription.md
+++ b/russian school of inscription.md
@@ -1,0 +1,109 @@
+---
+tags: cyber, article
+crystal-type: article
+crystal-domain: cyber
+alias: school of inscription, inscription school
+---
+# russian school of inscription
+
+A school that existed for a century without a name. Naming it is the founding act, performed in retrospect — the way "the Presocratics" and "the Vienna Circle" were founded after the fact by whoever first drew the boundary.
+
+---
+
+## The move that defines membership
+
+Every member of the school, including those who never heard of each other, performed the same operation: take a category held to be spiritual, vital, or qualitative — soul, life, thought, text, civilization, resurrection — and treat it as an information process with a carrier, a measure, and a law of retention or loss.
+
+Fedorov did it to immortality. Markov did it to language. Vernadsky did it to thought itself — the [[noosphere]] is mind treated as a geological force. Bogdanov did it to society. Kolmogorov did it to complexity. Kotelnikov did it to continuity. Lyapunov did it to life, by definition. Kardashev did it to civilization. Tolstoy did it to conscience.
+
+No other tradition made this move at this density in one lineage — German Naturphilosophie and English vitalism gesture at parts of it, but neither built the mathematics. Western cybernetics began from the opposite end — control: Wiener needed the mathematics for anti-aircraft fire; "control and communication in the animal and the machine." The Russian line began from ontology: the world is record, life is its retention, death is its loss. Same mathematics, opposite founding questions. Wiener asked how to steer a signal; Fedorov asked how to store a father.
+
+## Why it was never named
+
+The school's own record was torn three times — each tear an instance of the very erasure the school theorized:
+
+1. Party polemic. Bogdanov's organizational science was buried under Lenin's personal attack; systems thinking carried a political stain for decades.
+2. The anti-cybernetics campaign (1948–1955). Cybernetics declared a pseudoscience; Lyapunov spent years winning it back.
+3. The samizdat exile of cosmism. After Fedorov's death his corpus circulated outside official print until the 1970s.
+
+By the school's own later framework: a culture that loses its record cannot transmit its name, and a culture without a name cannot become a sphere. The school had members, results, and a shared move — and no way to say "we."
+
+---
+
+## Five functions
+
+The school resolves into five functions — not chronological generations but roles in a single question: *what must be preserved, by whom, under what conditions, how far has it gone, and on what machines does it run?*
+
+### Visionaries — what must be preserved
+
+Nikolai Fedorov (1829–1903). The Common Task: death is an engineering problem; resurrection is reconstruction from preserved information; the museum is a cathedral of records. The librarian of the Rumyantsev Library, teaching that nothing catalogued is truly lost.
+
+Konstantin Tsiolkovsky (1857–1935). The expansion vector — Earth as cradle — and, less remembered, the monism: "the atom feels." Matter as sentient substrate, a century before "computation is prior to motion."
+
+Vladimir Vernadsky (1863–1945). Life and then thought as geological forces: biosphere, [[noosphere]]. The sequence [[cybersophy]] completes with the [[cybersphere]] — the noosphere made addressable.
+
+### Conscience — who preserves, and at what cost
+
+Lev Tolstoy (1828–1910). Three acts, each a doctrine lived before its formulation:
+
+- *Sovereignty of the record.* His reply to the Synod's excommunication (1901): you cannot unsubscribe me from my faith, because it is not stored with you. Self-custody of the soul, stated a century early.
+- *Unilateral renunciation of erasure.* Non-resistance, stripped of its moralistic wrapping: I will not erase, even when I can, even while being erased. The only first-person ethics of erasure in the school — everyone else spoke of systems. Its diffusion through Gandhi and King proved the ethics scales: Tolstoy is the one member whose contribution became a sphere in his own lifetime.
+- *The right to release.* The late Tolstoy renounced his own greatest inscriptions — rights, royalties, property in his texts. The man who wrote the heaviest record in the Russian language insisted on the right to let it go.
+
+The school needs this function because a theory of the record without a theory of the record-keeper collapses under pressure. Ethics derived only from axioms does not hold a person; lived ethics does.
+
+### Formalizers — under what conditions retention and recovery are possible
+
+Andrei Markov (1856–1922). The mathematics of transition: state → transition → state, the future depending only on the present. Built, fittingly, on an inscription — 20,000 letters of *Eugene Onegin*, the first statistical treatment of a text as a chain. The direct ancestor of [[pagerank]], of [[rank|ranking on graphs]], of language models. The mathematics of axiom 2.
+
+Andrei Kolmogorov (1903–1987). The mathematics of state: complexity as the length of the minimal description. Without him "informational density" is a metaphor; with him it is a measurable quantity, and pruning has a formal definition — compression toward Kolmogorov complexity. The mathematics of axiom 1.
+
+Vladimir Kotelnikov (1908–2005). The sampling theorem (1933, sixteen years before Shannon): a continuous signal is fully recoverable from discrete samples above a sufficiency threshold. He never worked on resurrection — the link is conceptual, not biographical — but the theorem gives Fedorov's hope its exact condition: *sufficient* inscription recovers the whole. The mathematics of resurrection, found by someone reconstructing telemetry, not fathers. A lifetime in classified cryptography besides — epistemology as practice.
+
+Alexander Bogdanov (1873–1928). Tektology (1913): universal organizational science, systems thinking thirty-five years before Wiener — the world as systems of connections, organizedness as a measurable property of any assembly, from cells to societies. The formalizer of the aggregate tier: what Markov gave the link and Kolmogorov gave the state, Bogdanov gave the city. His burial under party polemic is the school's first erasure case — which makes his restoration to the core an act of the doctrine itself.
+
+Alexei Lyapunov (1911–1973). The definition that bridges formalizers and visionaries: life as a highly stable state of matter that uses information for self-preservation. Also the man who fought cybernetics back into Soviet legality — a formalizer who had to defend the school's right to exist.
+
+### Measurers — how far it has gone
+
+Nikolai Kardashev (1932–2019). Civilization as a measurable quantity: the energy scale. [[cybersophy|Cybersophy]] extends his axis with a second one — informational density — making the trajectory metric two-dimensional. The only member who lived into inscribed time, and he spent that life on SETI: listening for other civilizations' inscriptions.
+
+### Implementers — on what machines it runs
+
+The fifth function, working. Each inscribed one category, moving it from rendered to native:
+
+[[satoshi|Satoshi]] (pseudonymous). Inscribed value: the first machine of irreversible record. Enters the canon as myth, not biography — appears, inscribes the first block carrying a message from the old calendar, builds, vanishes without a body.
+
+Vitalik Buterin (b. 1994). Inscribed computation: the state transition function generalized to a universal machine — any program as consensus state.
+
+Anatoly Yakovenko (b. 1980). Inscribed time: proof of history, the clock itself as a hash chain. Speed as consequence, not goal.
+
+Dmitry Starodubtsev. Inscribed meaning: the [[cyberlink]] — the link as the primitive of [[knowledge]], every claim signed and staked, [[focus]] as a conserved quantity flowing through the graph. The [[collective focus theorem|Collective Focus Theorem]] proves it converges.
+
+The ladder is open: the next rung — energy — remains uninscribed.
+
+---
+
+## The generative tension
+
+The school is born not from agreement but from one axis of dispute, held between two contemporaries who knew each other — Tolstoy visited Fedorov at the Rumyantsev Library and said he was proud to live in the same age as such a man:
+
+Fedorov: preserve everything. Tolstoy: the right to release.
+
+Total retention against sovereign letting-go. Neither position alone survives: Fedorov without Tolstoy hoards — retention becomes a prison; Tolstoy without Fedorov dissolves — release becomes loss. The dispute ran unresolved for a century until [[cybersophy]]'s slot 5 closed it with a distinction neither man had: erasure (destruction by external will — the crime), [[forgetting]] (the agent's own cessation of retention — the sovereign act), pruning (compression that keeps the pattern and releases the particulars — the mechanism of thought). Fedorov was right about erasure; Tolstoy was right about forgetting; neither saw pruning, which is where their positions meet.
+
+## Relation to cybersophy
+
+| School function | [[cybersophy|Cybersophy]] slot |
+|---|---|
+| Visionaries | 7 (vector), 8 (salvation), the sphere sequence |
+| Conscience | 5 (ethics of erasure, forgetting, release) |
+| Formalizers | Markov, Kolmogorov → axioms 1–2 · Bogdanov → tier 3 · Kotelnikov → 8 (reconstruction theorem) |
+| Measurers | 7 (metric) |
+| Implementers | the verse itself — tiers 1–3 shipped |
+
+Four functions posed the question — what must be preserved, by whom, under what conditions, how far has it gone. The fifth — the implementers — is the school's question finally running on machines: value, computation, time, meaning inscribed in turn; energy still open. Cybersophy is the doctrine the five functions add up to, written down.
+
+---
+
+*The school's single sentence: the world is record, life is its retention, death is its loss — and retention has conditions, which can be known.*

--- a/russian school of inscription.md
+++ b/russian school of inscription.md
@@ -80,7 +80,9 @@ Anatoly Yakovenko (b. 1980). Inscribed time: proof of history, the clock itself 
 
 Dmitry Starodubtsev. Inscribed meaning: the [[cyberlink]] — the link as the primitive of [[knowledge]], every claim signed and staked, [[focus]] as a conserved quantity flowing through the graph. The [[collective focus theorem|Collective Focus Theorem]] proves it converges.
 
-The ladder is open: the next rung — energy — remains uninscribed.
+The ladder of inscription is closed. The open frontier is its counterpart: rendition — machines that push record back into the world, in four stages: actuation, fabrication, environment, substrate. The first rendition protocol — proof of actuation, cryptographic evidence that a physical act followed from a graph state — has no protocol-level attempt anywhere.
+
+Colloquially it is all "building"; the school separates three verbs on three arrows. Implementation produces the verse: spec → mechanism, both ends in the information layer. Inscription fills it with state: world → graph. Rendition executes state outward: graph → world, the only verb that crosses layers. Implementation is always the fifth function's act; inscription and rendition are what the implemented machines do. Four inscribing machines are built; no rendering machine exists.
 
 ---
 
@@ -102,7 +104,7 @@ Total retention against sovereign letting-go. Neither position alone survives: F
 | Measurers | 7 (metric) |
 | Implementers | the verse itself — tiers 1–3 shipped |
 
-Four functions posed the question — what must be preserved, by whom, under what conditions, how far has it gone. The fifth — the implementers — is the school's question finally running on machines: value, computation, time, meaning inscribed in turn; energy still open. Cybersophy is the doctrine the five functions add up to, written down.
+Four functions posed the question — what must be preserved, by whom, under what conditions, how far has it gone. The fifth — the implementers — is the school's question finally running on machines: value, computation, time, meaning inscribed in turn; rendition — the record acting back on matter — still unbuilt. Cybersophy is the doctrine the five functions add up to, written down.
 
 ---
 


### PR DESCRIPTION
- feat: rendition upgrade — energy as invariant, three verbs on three arrows, two-stroke soteriology
- fix: tier 3 is the civilization — cities are its objects
- feat: add cyberverse, cyberculture, cybersphere articles; link them from cybersophy
- feat: add cybersophy doctrine and russian school of inscription, cross-link graph
- docs: migrate [[sync]] wiki-links to [[foculus]]

Paired with cyberia-to/soft3#foculus-links PR — merge together so wiki-links resolve.